### PR TITLE
Update AWSS3Provider.ts

### DIFF
--- a/packages/storage/src/Providers/AWSS3Provider.ts
+++ b/packages/storage/src/Providers/AWSS3Provider.ts
@@ -206,6 +206,7 @@ export default class AWSS3Provider implements StorageProvider {
 			expires,
 			metadata,
 			tagging,
+			acl
 		} = opt;
 		const {
 			serverSideEncryption,
@@ -256,6 +257,9 @@ export default class AWSS3Provider implements StorageProvider {
 			if (SSEKMSKeyId) {
 				params.SSEKMSKeyId = SSEKMSKeyId;
 			}
+		}
+		if (acl) {
+			params.ACL = acl;
 		}
 
 		try {


### PR DESCRIPTION
Honor the acl config param.
Attempts to fix https://github.com/aws-amplify/amplify-js/issues/960

_Issue #, if available:_
960

_Description of changes:_
The put function does nothing if a config value for acl or level is passed, the comment in the function suggests that "level" should be valid but the code does nothing about it. Chose to implement `acl` for compatibility with [the sdk](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
